### PR TITLE
make map div id unique

### DIFF
--- a/client/map.coffee
+++ b/client/map.coffee
@@ -1,13 +1,20 @@
+uniqueId = (length=8) ->
+  id = ""
+  id += Math.random().toString(36).substr(2) while id.length < length
+  id.substr 0, length
+
 window.plugins.map =
+
   bind: (div, item) ->
   emit: (div, item) ->
     if (!$("link[href='http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css']").length)
       $('<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css">').appendTo("head")
     wiki.getScript "http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js", ->
       div.css 'height', '300px'
-      div.attr 'id', 'map'
+      mapId = 'map-' + uniqueId()
+      div.attr 'id', mapId
 
-      map = L.map('map').setView(item.latlng || [40.735383, -73.984655], item.zoom || 13)
+      map = L.map(mapId).setView(item.latlng || [40.735383, -73.984655], item.zoom || 13)
 
       L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
         attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'


### PR DESCRIPTION
fix for #5 

Did think about simply adding `item.id` to the map's div id, but that would not be enough as view either a previous version, or another copy, of the page would try and create maps with none unique names.

So, just create a [unique id](http://coffeescriptcookbook.com/chapters/strings/generating-a-unique-id) and append that to 'map'.
