### PR TITLE
gallery of common maps and selective forwarding of markers to them

### DIFF
--- a/client/map.coffee
+++ b/client/map.coffee
@@ -72,9 +72,17 @@ emit = ($item, item) ->
   {caption, markers, boundary} = parse item.text, $item
 
   # announce our capability to produce markers in native and geojson format
+
   $item.addClass 'marker-source'
+
+  showing = []
   $item.get(0).markerData = ->
-    parse(item.text).markers
+    opened = showing.filter (s) -> s.leaflet._popup._isOpen
+    if opened.length
+      opened.map (s) -> s.marker
+    else
+      parse(item.text).markers
+
   $item.get(0).markerGeo = ->
     type: 'FeatureCollection'
     features: parse(item.text).markers.map(feature)
@@ -124,10 +132,11 @@ emit = ($item, item) ->
       return unless markers
       for p in markers
         markerLabel  = htmlDecode(wiki.resolveLinks(p.label))
-        L.marker([p.lat, p.lon])
+        mkr = L.marker([p.lat, p.lon])
           .bindPopup( markerLabel )
           .openPopup()
           .addTo(map);
+        showing.push {leaflet:mkr, marker:p}
 
     # add markers on the map
     showMarkers markers

--- a/pages/about-map-plugin
+++ b/pages/about-map-plugin
@@ -61,6 +61,11 @@
       "type": "paragraph",
       "id": "25aadbd0c660f115",
       "text": "See [[About Map Properties]] for defaults internal to maps."
+    },
+    {
+      "type": "paragraph",
+      "id": "0685e72a4915355d",
+      "text": "See [[Street Map]] or [[Aerial Map]] or [[Topo Map]] tiles."
     }
   ],
   "journal": [
@@ -602,6 +607,37 @@
         "text": "Shift-double-click to add a marker at a map location."
       },
       "date": 1467904348593
+    },
+    {
+      "type": "add",
+      "id": "0685e72a4915355d",
+      "item": {
+        "type": "paragraph",
+        "id": "0685e72a4915355d",
+        "text": "See [[Street Map]], [[Aerial Map]] or [[Topo Map]]"
+      },
+      "after": "25aadbd0c660f115",
+      "date": 1469057959390
+    },
+    {
+      "type": "edit",
+      "id": "0685e72a4915355d",
+      "item": {
+        "type": "paragraph",
+        "id": "0685e72a4915355d",
+        "text": "See [[Street Map]] or [[Aerial Map]] or [[Topo Map]] for other views."
+      },
+      "date": 1469057973730
+    },
+    {
+      "type": "edit",
+      "id": "0685e72a4915355d",
+      "item": {
+        "type": "paragraph",
+        "id": "0685e72a4915355d",
+        "text": "See [[Street Map]] or [[Aerial Map]] or [[Topo Map]] tiles."
+      },
+      "date": 1469057996289
     }
   ]
 }

--- a/pages/aerial-map
+++ b/pages/aerial-map
@@ -1,0 +1,126 @@
+{
+  "title": "Aerial Map",
+  "story": [
+    {
+      "type": "paragraph",
+      "id": "5d9fc7baa91a6223",
+      "text": "Here we place markers from the lineup on an aerial map."
+    },
+    {
+      "type": "map",
+      "id": "d66f734b7a58c89c",
+      "text": "Aerial Map\n\nTiles © Esri — Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community\nLINEUP",
+      "tile": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}.png"
+    },
+    {
+      "type": "paragraph",
+      "id": "1a21fa44bb1de509",
+      "text": "See [[Street Map]] or [[Topo Map]] for other views."
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "Aerial Map",
+        "story": []
+      },
+      "date": 1469053918295
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "5d9fc7baa91a6223"
+      },
+      "id": "5d9fc7baa91a6223",
+      "type": "add",
+      "date": 1469053924947
+    },
+    {
+      "type": "edit",
+      "id": "5d9fc7baa91a6223",
+      "item": {
+        "type": "paragraph",
+        "id": "5d9fc7baa91a6223",
+        "text": "Here we place markers found in the lineup on an aerial map."
+      },
+      "date": 1469053965030
+    },
+    {
+      "type": "edit",
+      "id": "5d9fc7baa91a6223",
+      "item": {
+        "type": "paragraph",
+        "id": "5d9fc7baa91a6223",
+        "text": "Here we place markers from the lineup on an aerial map."
+      },
+      "date": 1469053983674
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "d66f734b7a58c89c"
+      },
+      "id": "d66f734b7a58c89c",
+      "type": "add",
+      "after": "5d9fc7baa91a6223",
+      "date": 1469054000701
+    },
+    {
+      "type": "edit",
+      "id": "d66f734b7a58c89c",
+      "item": {
+        "type": "map",
+        "id": "d66f734b7a58c89c",
+        "text": "Aerial Map\nLINEUP"
+      },
+      "date": 1469054014682
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "1a21fa44bb1de509"
+      },
+      "id": "1a21fa44bb1de509",
+      "type": "add",
+      "after": "d66f734b7a58c89c",
+      "date": 1469054018607
+    },
+    {
+      "type": "edit",
+      "id": "1a21fa44bb1de509",
+      "item": {
+        "type": "paragraph",
+        "id": "1a21fa44bb1de509",
+        "text": "See [[Street Map]] or [[Topo Map]] for other views."
+      },
+      "date": 1469054046847
+    },
+    {
+      "type": "edit",
+      "id": "d66f734b7a58c89c",
+      "item": {
+        "type": "map",
+        "id": "d66f734b7a58c89c",
+        "text": "Aerial Map\nTiles © Esri — Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community\nLINEUP",
+        "tile": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}.png"
+      },
+      "date": 1469055278845
+    },
+    {
+      "type": "edit",
+      "id": "d66f734b7a58c89c",
+      "item": {
+        "type": "map",
+        "id": "d66f734b7a58c89c",
+        "text": "Aerial Map\n\nTiles © Esri — Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community\nLINEUP",
+        "tile": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}.png"
+      },
+      "date": 1469055303284
+    },
+    {
+      "type": "fork",
+      "date": 1469058071260
+    }
+  ]
+}

--- a/pages/street-map
+++ b/pages/street-map
@@ -1,0 +1,143 @@
+{
+  "title": "Street Map",
+  "story": [
+    {
+      "type": "paragraph",
+      "id": "d64fea7519058523",
+      "text": "Here we place markers from the lineup on a street map."
+    },
+    {
+      "type": "map",
+      "id": "4859ef0eb001b3b8",
+      "text": "Street Map\n\n© OpenStreetMap contributors.\nCartography licensed CC BY-SA. [http://www.openstreetmap.org/copyright link]\nLINEUP"
+    },
+    {
+      "type": "paragraph",
+      "id": "e384ed28baee4dcd",
+      "text": "See [[Aerial Map]] or [[Topo Map]] for other views."
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "Street Map",
+        "story": []
+      },
+      "date": 1469019674326
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "d64fea7519058523"
+      },
+      "id": "d64fea7519058523",
+      "type": "add",
+      "date": 1469019720883
+    },
+    {
+      "type": "edit",
+      "id": "d64fea7519058523",
+      "item": {
+        "type": "paragraph",
+        "id": "d64fea7519058523",
+        "text": "Here we view place markers that we find in the lineup."
+      },
+      "date": 1469019773114
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "4859ef0eb001b3b8"
+      },
+      "id": "4859ef0eb001b3b8",
+      "type": "add",
+      "after": "d64fea7519058523",
+      "date": 1469019785243
+    },
+    {
+      "type": "edit",
+      "id": "4859ef0eb001b3b8",
+      "item": {
+        "type": "map",
+        "id": "4859ef0eb001b3b8",
+        "text": "Street Map\nLINEUP"
+      },
+      "date": 1469019812734
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "e384ed28baee4dcd"
+      },
+      "id": "e384ed28baee4dcd",
+      "type": "add",
+      "after": "4859ef0eb001b3b8",
+      "date": 1469019824129
+    },
+    {
+      "type": "edit",
+      "id": "e384ed28baee4dcd",
+      "item": {
+        "type": "paragraph",
+        "id": "e384ed28baee4dcd",
+        "text": "See [[Aerial Map]] or [[Topo Map]] for other views."
+      },
+      "date": 1469019863276
+    },
+    {
+      "type": "edit",
+      "id": "d64fea7519058523",
+      "item": {
+        "type": "paragraph",
+        "id": "d64fea7519058523",
+        "text": "Here we place markers found in the lineup on a steet map."
+      },
+      "date": 1469019914242
+    },
+    {
+      "type": "edit",
+      "id": "4859ef0eb001b3b8",
+      "item": {
+        "type": "map",
+        "id": "4859ef0eb001b3b8",
+        "text": "Street Map\n\n© OpenStreetMap contributors. \nLINEUP"
+      },
+      "date": 1469057096700
+    },
+    {
+      "type": "edit",
+      "id": "4859ef0eb001b3b8",
+      "item": {
+        "type": "map",
+        "id": "4859ef0eb001b3b8",
+        "text": "Street Map\n\n© OpenStreetMap contributors. Cartography licensed CC BY-SA.\nLINEUP"
+      },
+      "date": 1469057299549
+    },
+    {
+      "type": "edit",
+      "id": "4859ef0eb001b3b8",
+      "item": {
+        "type": "map",
+        "id": "4859ef0eb001b3b8",
+        "text": "Street Map\n\n© OpenStreetMap contributors.\nCartography licensed CC BY-SA. [http://www.openstreetmap.org/copyright link]\nLINEUP"
+      },
+      "date": 1469057332250
+    },
+    {
+      "type": "fork",
+      "date": 1469058035735
+    },
+    {
+      "type": "edit",
+      "id": "d64fea7519058523",
+      "item": {
+        "type": "paragraph",
+        "id": "d64fea7519058523",
+        "text": "Here we place markers from the lineup on a street map."
+      },
+      "date": 1469058184546
+    }
+  ]
+}

--- a/pages/topo-map
+++ b/pages/topo-map
@@ -1,0 +1,116 @@
+{
+  "title": "Topo Map",
+  "story": [
+    {
+      "type": "paragraph",
+      "id": "9b7f4d5d1dd25053",
+      "text": "Here we place markers from the lineup on a topo map."
+    },
+    {
+      "type": "map",
+      "id": "496dc45cc5efe8ae",
+      "text": "Topo Map\n\nTiles © Esri — Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community\nLINEUP",
+      "tile": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}.png"
+    },
+    {
+      "type": "paragraph",
+      "id": "6ccfd83632465922",
+      "text": "See [[Street Map]] or [[Aerial Map]]"
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "Topo Map",
+        "story": []
+      },
+      "date": 1469056172532
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "9b7f4d5d1dd25053"
+      },
+      "id": "9b7f4d5d1dd25053",
+      "type": "add",
+      "date": 1469056175167
+    },
+    {
+      "type": "edit",
+      "id": "9b7f4d5d1dd25053",
+      "item": {
+        "type": "paragraph",
+        "id": "9b7f4d5d1dd25053",
+        "text": "Here we place markers from the lineup on a topo map."
+      },
+      "date": 1469056194533
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "496dc45cc5efe8ae"
+      },
+      "id": "496dc45cc5efe8ae",
+      "type": "add",
+      "after": "9b7f4d5d1dd25053",
+      "date": 1469056200841
+    },
+    {
+      "type": "edit",
+      "id": "496dc45cc5efe8ae",
+      "item": {
+        "type": "map",
+        "id": "496dc45cc5efe8ae",
+        "text": "Topo Map\nLINEUP"
+      },
+      "date": 1469056224404
+    },
+    {
+      "type": "edit",
+      "id": "496dc45cc5efe8ae",
+      "item": {
+        "type": "map",
+        "id": "496dc45cc5efe8ae",
+        "text": "Topo Map\n\nTiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community\nLINEUP",
+        "tile": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}.png"
+      },
+      "date": 1469056531044
+    },
+    {
+      "type": "edit",
+      "id": "496dc45cc5efe8ae",
+      "item": {
+        "type": "map",
+        "id": "496dc45cc5efe8ae",
+        "text": "Topo Map\n\nTiles © Esri — Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community\nLINEUP",
+        "tile": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}.png"
+      },
+      "date": 1469056572675
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "6ccfd83632465922"
+      },
+      "id": "6ccfd83632465922",
+      "type": "add",
+      "after": "496dc45cc5efe8ae",
+      "date": 1469056609881
+    },
+    {
+      "type": "edit",
+      "id": "6ccfd83632465922",
+      "item": {
+        "type": "paragraph",
+        "id": "6ccfd83632465922",
+        "text": "See [[Street Map]] or [[Aerial Map]]"
+      },
+      "date": 1469056632654
+    },
+    {
+      "type": "fork",
+      "date": 1469058109488
+    }
+  ]
+}


### PR DESCRIPTION
We add about pages for common maps that can be cited to render markers from the lineup.

![image](https://cloud.githubusercontent.com/assets/12127/17007084/b1233c28-4e9a-11e6-8d01-d3f3455f8683.png)

Here we show three views of the Wind River Confluence. [wiki](http://ward.asia.wiki.org/wind-river-confluence.html)