### PR TITLE
add overlay maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /*/*.js
 /*/*.map
+status
 node_modules
 npm-debug.log

--- a/client/map.coffee
+++ b/client/map.coffee
@@ -59,7 +59,7 @@ parse = (text, $item) ->
       markers = markers.concat lineup($item)
     else if m = /^WEBLINK *(.*)$/.exec line
       weblink = m[1]
-    else if m = /^OVERLAY *(.+?) ([+-]?\d+\.\d+),([+-]?\d+\.\d+) ([+-]?\d+\.\d+),([+-]?\d+\.\d+)$/.exec line
+    else if m = /^OVERLAY *(.+?) ([+-]?\d+\.\d+), ?([+-]?\d+\.\d+) ([+-]?\d+\.\d+), ?([+-]?\d+\.\d+)$/.exec line
       overlays = (overlays||[]).concat {url:m[1], bounds:[[m[2],m[3]],[m[4],m[5]]]}
     else
       captions.push resolve(line)

--- a/client/map.coffee
+++ b/client/map.coffee
@@ -44,6 +44,7 @@ lineup = ($item) ->
 parse = (text, $item) ->
   captions = []
   markers = []
+  overlays = null
   boundary = null
   weblink = null
   for line in text.split /\n/
@@ -58,11 +59,14 @@ parse = (text, $item) ->
       markers = markers.concat lineup($item)
     else if m = /^WEBLINK *(.*)$/.exec line
       weblink = m[1]
+    else if m = /^OVERLAY *(.+?) ([+-]?\d+\.\d+),([+-]?\d+\.\d+) ([+-]?\d+\.\d+),([+-]?\d+\.\d+)$/.exec line
+      overlays = (overlays||[]).concat {url:m[1], bounds:[[m[2],m[3]],[m[4],m[5]]]}
     else
       captions.push resolve(line)
   boundary = markers unless boundary?
   result = {markers, caption: captions.join('<br>'), boundary}
   result.weblink = weblink if weblink?
+  result.overlays = overlays if overlays?
   result
 
 feature = (marker) ->
@@ -75,7 +79,7 @@ feature = (marker) ->
 
 emit = ($item, item) ->
 
-  {caption, markers, boundary, weblink} = parse item.text, $item
+  {caption, markers, boundary, weblink, overlays} = parse item.text, $item
 
   # announce our capability to produce markers in native and geojson format
 
@@ -139,6 +143,10 @@ emit = ($item, item) ->
     L.tileLayer(tile, {
       attribution: tileCredits
       }).addTo(map)
+
+    # add specialized map overlays
+    for o in overlays||[]
+      L.imageOverlay(o.url, o.bounds, {opacity:0.6, interactive:true}).addTo(map)
 
     openWeblink = (e) ->
       return unless link = e.target.options.weblink

--- a/pages/about-map-keywords
+++ b/pages/about-map-keywords
@@ -27,6 +27,11 @@
       "text": "Say __WEBLINK url__ to link to external maps."
     },
     {
+      "type": "markdown",
+      "id": "2f113729f238ed50",
+      "text": "Say __OVERLAY url sw ne__ to superimpose an image."
+    },
+    {
       "type": "paragraph",
       "id": "5285e8e26a7c08a5",
       "text": "If LINEUP is omitted, only markers from this map will be used. If BOUNDARY is omitted all of the markers will be used to position and zoom the map."
@@ -40,6 +45,11 @@
       "type": "markdown",
       "id": "a990cdad1bbaaeee",
       "text": "Markers will open WEBLINK urls on double-click. The url will substitute the marker's decimal coordinates in place of __{LAT}__ and __{LON}__."
+    },
+    {
+      "type": "paragraph",
+      "id": "7bc484c2561f0a84",
+      "text": "Overlay images are specialized maps aligned on the southwest and northeast corners. Separate each parameter with a single space. The decimal lat and lon of each corner is separated with a comma, but no space."
     }
   ],
   "journal": [
@@ -477,6 +487,82 @@
       "after": "3fee42467842feeb",
       "id": "a990cdad1bbaaeee",
       "date": 1470004140898
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "2f113729f238ed50"
+      },
+      "id": "2f113729f238ed50",
+      "type": "add",
+      "after": "a990cdad1bbaaeee",
+      "date": 1549849347523
+    },
+    {
+      "type": "move",
+      "order": [
+        "eb285095c3493c4e",
+        "aaa126d593f35d19",
+        "a3a9ffecac459f8c",
+        "bf21946c40683589",
+        "10d7a18f2ec54c3f",
+        "2f113729f238ed50",
+        "5285e8e26a7c08a5",
+        "3fee42467842feeb",
+        "a990cdad1bbaaeee"
+      ],
+      "id": "2f113729f238ed50",
+      "date": 1549849354765
+    },
+    {
+      "type": "edit",
+      "id": "2f113729f238ed50",
+      "item": {
+        "type": "markdown",
+        "id": "2f113729f238ed50",
+        "text": "Say _OVERLAY url sw ne_ to superimpose an image."
+      },
+      "date": 1549849449709
+    },
+    {
+      "type": "edit",
+      "id": "2f113729f238ed50",
+      "item": {
+        "type": "markdown",
+        "id": "2f113729f238ed50",
+        "text": "Say __OVERLAY url sw ne__ to superimpose an image."
+      },
+      "date": 1549849459859
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "7bc484c2561f0a84"
+      },
+      "id": "7bc484c2561f0a84",
+      "type": "add",
+      "after": "a990cdad1bbaaeee",
+      "date": 1549849500033
+    },
+    {
+      "type": "edit",
+      "id": "7bc484c2561f0a84",
+      "item": {
+        "type": "paragraph",
+        "id": "7bc484c2561f0a84",
+        "text": "Overlay images are specialized maps aligned on the southwest and northeast corners. Separate items with a single space. The decimal lat and lon of each corner is separated with a comma, but no space."
+      },
+      "date": 1549849669210
+    },
+    {
+      "type": "edit",
+      "id": "7bc484c2561f0a84",
+      "item": {
+        "type": "paragraph",
+        "id": "7bc484c2561f0a84",
+        "text": "Overlay images are specialized maps aligned on the southwest and northeast corners. Separate each parameter with a single space. The decimal lat and lon of each corner is separated with a comma, but no space."
+      },
+      "date": 1549849712076
     }
   ]
 }

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -96,4 +96,8 @@ describe 'map plugin', ->
       parse = map.parse "OVERLAY http://example.com 45.5,-122.0 44.5,-123.0"
       expect(parse).to.eql {markers:[], caption:'', boundary:[], overlays:[{url:'http://example.com',bounds:[[45.5,-122.0],[44.5,-123.0]]}]}
 
+    it 'should accept overlay url and bounds with space after comma', ->
+      parse = map.parse "OVERLAY http://example.com 45.5, -122.0 44.5, -123.0"
+      expect(parse).to.eql {markers:[], caption:'', boundary:[], overlays:[{url:'http://example.com',bounds:[[45.5,-122.0],[44.5,-123.0]]}]}
+
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -92,4 +92,8 @@ describe 'map plugin', ->
       parse = map.parse [n46,bo,li,bo+n47].join("\n")
       expect(parse).to.eql {markers:[p46,pi], caption:'', boundary:[p46,p47]}
 
+    it 'should accept overlay url and bounds', ->
+      parse = map.parse "OVERLAY http://example.com 45.5,-122.0 44.5,-123.0"
+      expect(parse).to.eql {markers:[], caption:'', boundary:[], overlays:[{url:'http://example.com',bounds:[[45.5,-122.0],[44.5,-123.0]]}]}
+
 


### PR DESCRIPTION
Leaflet is happy to [overlay images](https://leafletjs.com/reference-1.4.0.html#imageoverlay) so we add that capability with specialized markup.

![image](https://user-images.githubusercontent.com/12127/52543358-fceb5380-2d5d-11e9-970d-5392b839a2eb.png)

Here we overlay the George Fox University [campus map](https://www.georgefox.edu/maps_locations/inter_map/campus-map.pdf) within the city of Newberg, Oregon and then locate the Engineering Maker Hub on that map with a clickable marker.