### PR TITLE
Add 'PAGE' keyword. (FREEZE route)

### DIFF
--- a/client/map.coffee
+++ b/client/map.coffee
@@ -196,6 +196,7 @@ emit = ($item, item) ->
             lon: e.geocode.center.lng}
           if boundary.length > 1
             bounds = new L.LatLngBounds [ [p.lat, p.lon] for p in boundary ]
+            bounds = bounds.pad(0.3)
             map.flyToBounds bounds
           else if boundary.length == 1
             p = boundary[0]
@@ -256,6 +257,7 @@ emit = ($item, item) ->
                 L.marker([mark.lat, mark.lon]).addTo(newMarkerGroup)
               tmpBoundary = boundary.concat newMarkers
               bounds = new L.LatLngBounds [ [p.lat, p.lon] for p in tmpBoundary ]
+              bounds = bounds.pad(0.3)
               map.flyToBounds bounds
 
           container.addEventListener 'mouseleave', (e) ->
@@ -263,6 +265,7 @@ emit = ($item, item) ->
               newMarkerGroup.remove()
               if boundary.length > 1
                 bounds = new L.LatLngBounds [ [p.lat, p.lon] for p in boundary ]
+                bounds = bounds.pad(0.3)
                 map.flyToBounds bounds
               else if boundary.length == 1
                 p = boundary[0]
@@ -327,6 +330,7 @@ emit = ($item, item) ->
     # center map on markers or item properties
     if boundary.length > 1
       bounds = new L.LatLngBounds [ [p.lat, p.lon] for p in boundary ]
+      bounds = bounds.pad(0.3)
       map.fitBounds bounds
     else if boundary.length == 1
       p = boundary[0]

--- a/client/map.coffee
+++ b/client/map.coffee
@@ -131,13 +131,14 @@ emit = ($item, item) ->
   $item.get(0).markerData = ->
     opened = showing.filter (s) -> s.leaflet._popup._isOpen
     if opened.length
-      opened.map (s) -> s.marker
+      marlers = opened.map (s) -> s.marker
     else
-      parse(item).markers
+      markers = parse(item, $item).markers
+    return markers
 
   $item.get(0).markerGeo = ->
     type: 'FeatureCollection'
-    features: parse(item).markers.map(feature)
+    features: parse(item, $item).markers.map(feature)
 
   if (!$("link[href='https://unpkg.com/leaflet@1.7.1/dist/leaflet.css']").length)
     $('<link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css">').appendTo("head")

--- a/pages/about-map-keywords
+++ b/pages/about-map-keywords
@@ -13,6 +13,11 @@
     },
     {
       "type": "markdown",
+      "id": "98bca36bc7f177a6",
+      "text": "Say __PAGE__ to read markers from the page."
+    },
+    {
+      "type": "markdown",
       "id": "a3a9ffecac459f8c",
       "text": "Say __BOUNDARY__ to bound the markers found so far."
     },
@@ -44,7 +49,7 @@
     {
       "type": "paragraph",
       "id": "5285e8e26a7c08a5",
-      "text": "If LINEUP is omitted, only markers from this map will be used. If BOUNDARY is omitted all of the markers will be used to position and zoom the map."
+      "text": "If LINEUP or PAGE is omitted, only markers from this map will be used. If BOUNDARY is omitted all of the markers will be used to position and zoom the map."
     },
     {
       "type": "paragraph",
@@ -595,6 +600,27 @@
       },
       "after": "3a5368621911edac",
       "date": 1600166255226
+    },
+    {
+      "type": "edit",
+      "id": "5285e8e26a7c08a5",
+      "item": {
+        "type": "paragraph",
+        "id": "5285e8e26a7c08a5",
+        "text": "If LINEUP or PAGE is omitted, only markers from this map will be used. If BOUNDARY is omitted all of the markers will be used to position and zoom the map."
+      },
+      "date": 1659966468905
+    },
+    {
+      "type": "add",
+      "id": "98bca36bc7f177a6",
+      "item": {
+        "type": "markdown",
+        "id": "98bca36bc7f177a6",
+        "text": "Say __PAGE__ to read markers from the page."
+      },
+      "after": "aaa126d593f35d19",
+      "date": 1659966730211
     }
   ]
 }


### PR DESCRIPTION
This is a work in progress, and discussion.

This is something we discussed with the addition of images as markers sources, and so pages like the story telling, with maps, become simpler. See [Red Electric Bridge](http://trails.ward.asia.wiki.org/red-electric-bridge.html) for an example of such a page.

Adding 'PAGE' does not fit so easy with the either the current 'LINEUP' *up and to the left*, or how things get rendered. The map is currently rendered in the `emit`, at which point only the first image on the page has been rendered, so the map will only show the first image.

Once the page has rendered, `$item.siblings()` will contain all the map's siblings on the page, rather than just those above it on the page. *Similarly, editing an item of the page will force a render and as the other `marker-source` items on the page have been rendered, the map will see them and add markers for them. But, will need to be frozen to remain.*

One approach, that used here, is to extend FREEZE to reevaluate the marker sources on the page, and freeze them.

An alternative would be to delay the processing of `PAGE` until after the rest of the page has been rendered, moving it from `emit` to `bind`?