### PR TITLE
Add Street Map to the hamburger menu.

### DIFF
--- a/factory.json
+++ b/factory.json
@@ -1,1 +1,1 @@
-{"name":"Map","title":"Street Map","category":"data"}
+{"name":"Map","title":"Street Map","category":"data","pages":["Street Map"]}


### PR DESCRIPTION
This offers to collect markers present in the lineup and display them all on a map. Street Map is already an about page as is Aerial Map and Topo Map. We choose to offer only the most common map in the hamburger menu rather than clutter it with all alternatives. The Street Map page offers a direct link to the other variations.

I've not tested this commit but it seems obvious after examining another plugin.
https://github.com/fedwiki/wiki-plugin-search/blob/master/factory.json